### PR TITLE
[ENHANCEMENT] Hybrid ESM & CJS Builds

### DIFF
--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3436,13 +3436,13 @@ simple-swizzle@^0.2.2:
     is-arrayish "^0.3.1"
 
 "sk-auth@file:..":
-  version "0.3.5"
+  version "0.3.6"
   dependencies:
     cookie "^0.4.1"
     jsonwebtoken "^8.5.1"
 
 "sk-auth@file:../":
-  version "0.3.5"
+  version "0.3.6"
   dependencies:
     cookie "^0.4.1"
     jsonwebtoken "^8.5.1"

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,6 @@
 {
   "internal": true,
   "main": "../dist/client/index.js",
+  "module": "../dist/client/index.esm.js",
   "types": "../dist/client/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.6",
   "description": "Authentication library for use with SvelteKit featuring built-in OAuth providers and zero restriction customization!",
   "main": "dist/index.js",
+  "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",

--- a/providers/package.json
+++ b/providers/package.json
@@ -1,5 +1,6 @@
 {
   "internal": true,
   "main": "../dist/providers/index.js",
+  "module": "../dist/providers/index.esm.js",
   "types": "../dist/providers/index.d.ts"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,26 +8,50 @@ const globals = {
   ...packageJson.devDependencies,
 };
 
+/** @type {import('rollup').RollupOptions} */
+const baseConfig = {
+  input: ["src/**/*.ts"],
+  output: {
+    dir: "dist",
+    sourcemap: true,
+  },
+  plugins: [
+    esbuild(),
+    typescript({
+      emitDeclarationOnly: true,
+      sourceMap: false,
+    }),
+  ],
+  external: [
+    ...Object.keys(globals),
+    "@sveltejs/kit/assets/runtime/app/navigation",
+    "@sveltejs/kit/assets/runtime/app/stores",
+  ],
+};
+
+/** @type {Array.<import('rollup').RollupOptions>} */
 export default [
   {
-    input: ["src/**/*.ts"],
+    ...baseConfig,
     output: {
-      dir: "dist",
-      sourcemap: true,
+      ...baseConfig.output,
       format: "cjs",
     },
+    plugins: [...baseConfig.plugins, multiInput()],
+  },
+  {
+    ...baseConfig,
+    output: {
+      ...baseConfig.output,
+      format: "esm",
+    },
     plugins: [
-      esbuild(),
-      multiInput(),
-      typescript({
-        emitDeclarationOnly: true,
-        sourceMap: false,
+      ...baseConfig.plugins,
+      multiInput({
+        /** @param {string} output */
+        transformOutputPath: (output) =>
+          `${output.split(".").slice(0, -1).join(".")}.esm.${output.split(".").slice(-1)}`,
       }),
-    ],
-    external: [
-      ...Object.keys(globals),
-      "@sveltejs/kit/assets/runtime/app/navigation",
-      "@sveltejs/kit/assets/runtime/app/stores",
     ],
   },
 ];


### PR DESCRIPTION
# Overview

In response to #26 this PR adds a hybrid ES module and CommonJS build using Rollup's `multi-input` plugin, and multiple build configurations. The ESM output will rename all files to `.esm.js` and maps those correctly in the respective `package.json` files.

**Further testing required to see if this resolves issues with ESM in Vite.**