### PR TITLE
[Enhancement] Return access_token with user profile at end of OAuth flow

### DIFF
--- a/src/providers/oauth2.ts
+++ b/src/providers/oauth2.ts
@@ -87,6 +87,7 @@ export class OAuth2Provider<
     const res = await fetch(this.config.profileUrl!, {
       headers: { Authorization: `${ucFirst(tokens.token_type)} ${tokens.access_token}` },
     });
-    return await res.json();
+    const profile = await res.json();
+    return { ...profile, access_token: tokens.access_token };
   }
 }


### PR DESCRIPTION
# Summary

This enhancement returns the user's `access_token` with user profile at end of the OAuth flow. I needed this in the process of migrating from Sapper and Passport to Svelte-kit and sk-auth in order to facilitate additional API calls after OAuth.

## Context

Projects using OAuth often do so in order to acquire suitable `access_token`s with specifically requested scopes.

For example, a project might use Google OAuth with the scopes `https://www.googleapis.com/auth/youtube.upload` and `https://www.googleapis.com/auth/youtube` in order to use the [YouTube Data API](https://developers.google.com/youtube/v3/) on behalf of a user to check private information and upload videos.

sk-auth does not currently expose the user's `access_token` to Svelte-kit at the end of the OAuth flow.

## Solution 

This pull request makes it super easy to get the user's `access_token` by adding it to the  profile object returned by  `getUserProfile`.