### PR TITLE
✨ add github provider

### DIFF
--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -1,0 +1,50 @@
+import { OAuth2Provider, OAuth2ProviderConfig } from "./oauth2";
+
+export interface GitHubProfile {
+  id: number;
+  login: string;
+  avatar_url: string;
+  url: string;
+  name: string;
+  // complete with more info
+}
+
+export interface GitHubTokens {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+}
+
+type GitHubOAuth2ProviderConfig = OAuth2ProviderConfig<GitHubProfile, GitHubTokens>;
+
+const defaultConfig: Partial<GitHubOAuth2ProviderConfig> = {
+  id: "github",
+  scope: "user",
+  accessTokenUrl: "https://github.com/login/oauth/access_token",
+  authorizationUrl: "https://github.com/login/oauth/authorize",
+  profileUrl: "https://api.github.com/user",
+  headers: {
+    Accept: "application/json",
+  },
+};
+
+export class GitHubOAuth2Provider extends OAuth2Provider<
+  GitHubProfile,
+  GitHubTokens,
+  GitHubOAuth2ProviderConfig
+> {
+  constructor(config: GitHubOAuth2ProviderConfig) {
+    super({
+      ...defaultConfig,
+      ...config,
+    });
+  }
+
+  async getUserProfile(tokens: GitHubTokens): Promise<GitHubProfile> {
+    const tokenType = "token"; // 🤷‍♂️ token type returned is "bearer" but GitHub uses "token" keyword
+    const res = await fetch(this.config.profileUrl!, {
+      headers: { Authorization: `${tokenType} ${tokens.access_token}` },
+    });
+    return await res.json();
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -11,3 +11,5 @@ export type { ProfileCallback } from "./oauth2.base";
 export { OAuth2Provider } from "./oauth2";
 export { RedditOAuth2Provider } from "./reddit";
 export type { RedditProfile, RedditTokens } from "./reddit";
+export { GitHubOAuth2Provider } from "./github";
+export type { GitHubProfile, GitHubTokens } from "./github";


### PR DESCRIPTION
I needed this provider so I created first on my project and then sharing it to other with this PR.
I tested it and it works fine.

Also note that there is a lot of data retrieved from GitHub profile, I only put the most interesting properties. We could check the GitHub API documentation to complete the `GitHubProfile` type.