### PR TITLE
🎨 Fix prettier and eslint errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ SvelteKitAuth also comes with first-class support for Typescript out of the box,
 
 SvelteKitAuth is very easy to setup! All you need to do is instantiate the `SvelteKitAuth` class, and configure it with some default providers, as well as a JWT secret key used to verify the cookies:
 
-_**Warning**: env variables prefixed with `VITE_` can be exposed and leaked into client-side bundles if they are referenced in any client-side code. Make sure this is not the case, or consider using an alternative method such as loading them via dotenv directly instead._
+<i>**Warning**: env variables prefixed with `VITE_` can be exposed and leaked into client-side bundles if they are referenced in any client-side code. Make sure this is not the case, or consider using an alternative method such as loading them via dotenv directly instead.</i>
 
 ```ts
 export const appAuth = new SvelteKitAuth({

--- a/app/src/routes/profile.svelte
+++ b/app/src/routes/profile.svelte
@@ -6,6 +6,8 @@
   export const hydrate = dev;
 </script>
 
+<script></script>
+
 <svelte:head>
   <title>Profile | SvelteKitAuth</title>
 </svelte:head>

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "esbuild": "^0.12.1",
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-svelte3": "^3.2.1",
     "prettier": "^2.3.0",
     "rollup": "^2.48.0",
     "rollup-plugin-esbuild": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,6 +1539,11 @@ eslint-config-prettier@^8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
+eslint-plugin-svelte3@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-svelte3/-/eslint-plugin-svelte3-3.2.1.tgz#f0f24150ecea3061c38c69e282bea26dc3e660c6"
+  integrity sha512-YoBR9mLoKCjGghJ/gvpnFZKaMEu/VRcuxpSRS8KuozuEo7CdBH7bmBHa6FmMm0i4kJnOyx+PVsaptz96K6H/4Q==
+
 eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
Fix the errors reported by prettier and eslint

### README.md
prettier will report an error if there is a `_` in the middle of a sentence surrounded by _.
If the `_` and `*` are interchanged, prettier will format them as in the current source. And it will get an error.
The only way to achieve italicized display was with HTML tags.

### app/src/routes/profile.svelte
ESLint will report `'$session' is not defined  no-undef` error.
Strangely enough, inserting `<script></script>` does not report any error.
https://github.com/sveltejs/eslint-plugin-svelte3/issues/107#issuecomment-820747718

### package.json
The installation of eslint-plugin-svelte3 was missing