### PR TITLE
[FEATURE] Add Support to Specify Protocol in Auth Config

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,2 +1,2 @@
 export type Profile = any;
-export type CallbackResult = [Profile, string | null];
+export type CallbackResult = [Profile, string | null, { error: string } | null];


### PR DESCRIPTION
# Overview

Add `protocol` config option to `AuthConfig` and default to `http` in usages in `getBaseUrl()`.