### PR TITLE
[FIX] Fix Client Functions and Add Base Path Option

### DIFF
--- a/src/client/helpers.ts
+++ b/src/client/helpers.ts
@@ -1,0 +1,19 @@
+function mergePath(basePaths: (string | null)[], path: string) {
+  if (path.startsWith("/")) {
+    path = path.slice(1);
+  }
+  let retPath;
+  for (let basePath of basePaths) {
+    if (basePath !== null) {
+      if (!basePath.startsWith("/")) {
+        basePath = "/" + basePath;
+      }
+      if (!basePath.endsWith("/")) {
+        basePath = basePath + "/";
+      }
+      retPath = basePath + path;
+    }
+  }
+
+  return retPath;
+}

--- a/src/client/signIn.ts
+++ b/src/client/signIn.ts
@@ -1,14 +1,15 @@
 /* import { goto } from "@sveltejs/kit/assets/runtime/app/navigation";
 import { page } from "@sveltejs/kit/assets/runtime/app/stores"; */
 import type { LoadInput } from "@sveltejs/kit";
+import type { ClientRequestConfig } from "./types";
 
-interface SignInConfig {
+interface SignInConfig extends ClientRequestConfig {
   redirectUrl?: string;
 }
 
 export async function signIn(provider: string, data?: any, config?: SignInConfig) {
   if (data) {
-    const path = `/api/auth/callback/${provider}`;
+    const path = mergePath(["/api/auth", config?.basePath ?? null], `/callback/${provider}`);
     const res = await fetch(path, {
       method: "POST",
       headers: {
@@ -34,7 +35,7 @@ export async function signIn(provider: string, data?: any, config?: SignInConfig
     redirect: redirectUrl ?? "/",
   };
   const query = new URLSearchParams(queryData);
-  const path = `/api/auth/login/${provider}?${query}`;
+  const path = mergePath(["/api/auth", config?.basePath ?? null], `/signin/${provider}?${query}`);
 
   return path; // await goto(path);
 }

--- a/src/client/signOut.ts
+++ b/src/client/signOut.ts
@@ -1,14 +1,18 @@
 /* import { session as session$ } from "$app/stores"; */
 
-export async function signOut() {
-  let res = await fetch("/api/auth/signout", { method: "POST" });
+import type { ClientRequestConfig } from "./types";
+
+export async function signOut(config?: ClientRequestConfig) {
+  let res = await fetch(mergePath(["/api/auth", config?.basePath ?? null], "signout"), {
+    method: "POST",
+  });
   const { signout } = await res.json();
 
   if (!signout) {
     throw new Error("Sign out not successful!");
   }
 
-  res = await fetch("/api/auth/session");
+  res = await fetch(mergePath(["/api/auth", config?.basePath ?? null], "session"));
   const session = await res.json();
 
   return session;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,0 +1,3 @@
+export interface ClientRequestConfig {
+  basePath?: string;
+}


### PR DESCRIPTION
# Overview

1. Fix `signin` route in `client/signIn`.
2. Create `ClientRequestConfig` type with `basePath` optional parameter.
3. Create `mergePath()` helper to merge basePath from config/default with API route.
4. Add `config?` argument to `client/signOut`.