### PR TITLE
📌 Make @sveltejs/kit and build-esm peer dependencies optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,13 @@
   "peerDependencies": {
     "@sveltejs/kit": "next",
     "build-esm": "^4.2.2"
+  },
+  "peerDependenciesMeta": {
+    "@sveltejs/kit": {
+      "optional": true
+    },
+    "build-esm": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
close: #76

example pattern usage:
https://github.com/postcss/postcss-load-config/pull/218/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R43-R49