### PR TITLE
Fix: SvelteKit 1.0.0-next.259 Upgrade 

### DIFF
--- a/app/src/hooks.ts
+++ b/app/src/hooks.ts
@@ -1,17 +1,3 @@
-import type { Handle } from "@sveltejs/kit";
 import { appAuth } from "$lib/appAuth";
-
-export const handle: Handle = async ({ event, resolve }) => {
-  // TODO https://github.com/sveltejs/kit/issues/1046
-
-
-  if (event.request.query.has("_method")) {
-    event.request.method = event.request.query.get("_method").toUpperCase();
-  }
-
-  const response = await resolve(event);
-
-  return response;
-};
 
 export const { getSession } = appAuth;

--- a/app/src/routes/__layout.svelte
+++ b/app/src/routes/__layout.svelte
@@ -47,7 +47,7 @@
           "rounded-full",
         )}
       >
-        {#if $page.path === "/profile"}
+        {#if $page.url.pathname === "/profile"}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             class={clsx("h-6", "w-6")}
@@ -118,7 +118,7 @@
           "p-2",
           "rounded-full",
         )}
-        class:text-orange-500={$page.path === "/login"}
+        class:text-orange-500={$page.url.pathname === "/login"}
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/app/src/routes/profile.svelte
+++ b/app/src/routes/profile.svelte
@@ -245,12 +245,7 @@
   </div>
 
   <p class={clsx("text-lg", "mb-2")}>Session</p>
-  <pre
-    class={clsx(
-      "bg-gray-100",
-      "whitespace-pre-wrap",
-      "p-3",
-    )}>
+  <pre class={clsx("bg-gray-100", "whitespace-pre-wrap", "p-3")}>
     <code>{JSON.stringify($session, null, 2)}</code>
   </pre>
 </div>

--- a/app/svelte.config.js
+++ b/app/svelte.config.js
@@ -9,11 +9,6 @@ const config = {
       postcss: true,
     }),
   ],
-
-  kit: {
-    // hydrate the <div id="svelte"> element in src/app.html
-    target: "#svelte",
-  },
 };
 
 export default config;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,5 @@
 import type { GetSession, RequestHandler } from "@sveltejs/kit";
-import type { EndpointOutput } from "@sveltejs/kit/types/endpoint";
-import { RequestEvent } from "@sveltejs/kit/types/hooks";
+import type { EndpointOutput, RequestEvent } from "@sveltejs/kit";
 import cookie from "cookie";
 import * as jsonwebtoken from "jsonwebtoken";
 import type { JWT, Session } from "./interfaces";

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -1,5 +1,4 @@
-import type { EndpointOutput } from "@sveltejs/kit";
-import { RequestEvent } from "@sveltejs/kit/types/hooks";
+import type { EndpointOutput, RequestEvent } from "@sveltejs/kit";
 import type { Auth } from "../auth";
 import type { CallbackResult } from "../types";
 

--- a/src/providers/oauth2.base.ts
+++ b/src/providers/oauth2.base.ts
@@ -1,5 +1,4 @@
-import type { EndpointOutput } from "@sveltejs/kit/types/endpoint";
-import { RequestEvent } from "@sveltejs/kit/types/hooks";
+import type { EndpointOutput, RequestEvent } from "@sveltejs/kit";
 import type { Auth } from "../auth";
 import type { CallbackResult } from "../types";
 import { Provider, ProviderConfig } from "./base";

--- a/src/providers/oauth2.ts
+++ b/src/providers/oauth2.ts
@@ -1,4 +1,4 @@
-import { RequestEvent } from "@sveltejs/kit/types/hooks";
+import { RequestEvent } from "@sveltejs/kit";
 import type { Auth } from "../auth";
 import { ucFirst } from "../helpers";
 import { OAuth2BaseProvider, OAuth2BaseProviderConfig, OAuth2Tokens } from "./oauth2.base";

--- a/src/providers/twitter.ts
+++ b/src/providers/twitter.ts
@@ -1,4 +1,4 @@
-import { RequestEvent } from "@sveltejs/kit/types/hooks";
+import { RequestEvent } from "@sveltejs/kit";
 import type { Auth } from "../auth";
 import { OAuth2BaseProvider, OAuth2BaseProviderConfig } from "./oauth2.base";
 


### PR DESCRIPTION
This fixes several breaking changes from SvelteKit since its last upgrade. 

- Handle hook is no longer neccesary since the method is always uppercase and readonly (per https://developer.mozilla.org/en-US/docs/Web/API/Request/method)
- `$page.path` has moved to `$page.url.pathname`
- `config.kit.target` is not supported and must be removed
- `RequestEvent` and `EndpointOutput` have moved and are now top-level exports from `@sveltejs/kit`
