### PR TITLE
fix: rename endpoint method to uppercase

### DIFF
--- a/app/src/hooks.ts
+++ b/app/src/hooks.ts
@@ -4,7 +4,6 @@ import { appAuth } from "$lib/appAuth";
 export const handle: Handle = async ({ event, resolve }) => {
   // TODO https://github.com/sveltejs/kit/issues/1046
 
-
   if (event.request.query.has("_method")) {
     event.request.method = event.request.query.get("_method").toUpperCase();
   }

--- a/app/src/routes/profile.svelte
+++ b/app/src/routes/profile.svelte
@@ -245,12 +245,7 @@
   </div>
 
   <p class={clsx("text-lg", "mb-2")}>Session</p>
-  <pre
-    class={clsx(
-      "bg-gray-100",
-      "whitespace-pre-wrap",
-      "p-3",
-    )}>
+  <pre class={clsx("bg-gray-100", "whitespace-pre-wrap", "p-3")}>
     <code>{JSON.stringify($session, null, 2)}</code>
   </pre>
 </div>

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -188,7 +188,7 @@ export class Auth {
     };
   }
 
-  get: RequestHandler = async (event: RequestEvent): Promise<any> => {
+  GET: RequestHandler = async (event: RequestEvent): Promise<any> => {
     const { url } = event;
 
     if (url.pathname === this.getPath("csrf")) {
@@ -205,7 +205,7 @@ export class Auth {
     return await this.handleEndpoint(event);
   };
 
-  post: RequestHandler = async (event: RequestEvent) => {
+  POST: RequestHandler = async (event: RequestEvent) => {
     return await this.handleEndpoint(event);
   };
 


### PR DESCRIPTION
To fit sveltekit's recent update, should use uppercase GET and POST.